### PR TITLE
fix: don't convert empty strings to nils for values

### DIFF
--- a/lib/redis_counters/hash_counter.rb
+++ b/lib/redis_counters/hash_counter.rb
@@ -63,7 +63,7 @@ module RedisCounters
                    key.split(value_delimiter, -1)
                  end
 
-        values = values.map(&:presence).unshift(format_value(value))
+        values.unshift(format_value(value))
         values.delete_at(1) unless group_keys.present?
         result << Hash[keys.zip(values)].with_indifferent_access
       end

--- a/spec/redis_counters/hash_counter_spec.rb
+++ b/spec/redis_counters/hash_counter_spec.rb
@@ -257,7 +257,7 @@ describe RedisCounters::HashCounter do
       it { expect(counter.data(partitions).first[:param4]).to eq '1' }
       it { expect(counter.data(partitions).second[:value]).to eq 5 }
       it { expect(counter.data(partitions).second[:param3]).to eq '31' }
-      it { expect(counter.data(partitions).second[:param4]).to eq nil }
+      it { expect(counter.data(partitions).second[:param4]).to eq '' }
     end
 
     context 'when group_keys given' do


### PR DESCRIPTION
https://jira.railsc.ru/browse/CK-862 вот такая ошибка происходит из-за того что при прямом переходе на сайт, реферер это пустая строка, а тут она конвертируется в нил для того чтобы не надо было делать вот этого:

https://github.com/abak-press/apress-company_statistics/blob/master/app/counters/apress/company_statistics/counters/dumpers.rb#L322-L338

Так что я возвращаю обратно. Ещё как вариант можно убрать not null констрейнт с колонки.